### PR TITLE
Add ESP8266 to library.properties architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Manage many timed events.
 paragraph=The Arduino real-time loop stops advancing when you write delay() or use interrupts in your sketch. You can keep the real-time loop moving by using millis() to track time and create delay, but it's more complicated and soon becomes messy to manage. This lightweight library manages time the same way you would by setting a waypoint and calculating elapsed millis(). It is a simple replacement to manage your timed events with english instead of math.
 category=Timing
 url=https://github.com/alextaujenis/RBD_Timer
-architectures=avr
+architectures=avr,esp8266


### PR DESCRIPTION
Eliminate the following warning for Adafruit Feather HUZZAH ESP8266:

```
WARNING: library RBD_Timer claims to run on [avr] architecture(s) and may be incompatible with your current board which runs on [esp8266] architecture(s).
```
